### PR TITLE
chore: change to use Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     description: 'target of publish (`default` or `trustedTesters`)'
     default: "default"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Change to run on Node16, as Node12 is not supported.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

BREAKING CHANGE: Node.js version changes from 12 to 16

Closes #18