### PR TITLE
chore: change to use Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     description: 'target of publish (`default` or `trustedTesters`)'
     default: "default"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Change to run on Node20, as Node16 is not supported. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

BREAKING CHANGE: Node.js version changes from 16 to 20

Closes #25