### PR TITLE
Upgrade Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     description: 'target of publish (`default` or `trustedTesters`)'
     default: "default"
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-extension-upload",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "private": true,
   "description": "upload & publish extensions to the Chrome Web Store",
   "main": "lib/main.js",


### PR DESCRIPTION
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. For more information see [docs](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

@ maintainers: feel free to adjust :)